### PR TITLE
mnemonic from 24 to 12 words

### DIFF
--- a/screens/SignUp.js
+++ b/screens/SignUp.js
@@ -24,7 +24,7 @@ class SignUp extends Component {
 
   // move this function out
   generateMnemonic = async () => {
-    const randomBytes = await Random.getRandomBytesAsync(32);
+    const randomBytes = await Random.getRandomBytesAsync(16);
     let b = Buffer.from(randomBytes, 'base64').toString('hex');
     return bip39.entropyToMnemonic(b);
   }


### PR DESCRIPTION
Reducing mnemonic to 12 words. 

According to [the BIP32 spec](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#Security), 12 word mnemonic is as random as any private key.

>the actual security of a 12-word BIP39 seed phrase is only 128 bits. This is approximately the same strength as all Bitcoin private keys, so most experts consider it to be sufficiently secure.
[source](https://en.bitcoin.it/wiki/Seed_phrase)